### PR TITLE
Undefined variable $site_id

### DIFF
--- a/onelogin-saml-sso/php/functions.php
+++ b/onelogin-saml-sso/php/functions.php
@@ -631,7 +631,7 @@ function enroll_user_on_sites($user_id, $roles) {
 	$opts = array('number' => 1000);
 	$sites = get_sites($opts);
 	foreach ($sites as $site) {
-		if (get_blog_option($site_id, "onelogin_saml_autocreate") && !is_user_member_of_blog($user_id, $site->id)) {
+		if (get_blog_option($site->blog_id, "onelogin_saml_autocreate") && !is_user_member_of_blog($user_id, $site->id)) {
 			foreach($roles as $role) {
 				add_user_to_blog($site->id, $user_id, $role);
 			}

--- a/onelogin-saml-sso/php/functions.php
+++ b/onelogin-saml-sso/php/functions.php
@@ -631,7 +631,7 @@ function enroll_user_on_sites($user_id, $roles) {
 	$opts = array('number' => 1000);
 	$sites = get_sites($opts);
 	foreach ($sites as $site) {
-		if (get_blog_option($site->blog_id, "onelogin_saml_autocreate") && !is_user_member_of_blog($user_id, $site->id)) {
+		if (get_blog_option($site->id, "onelogin_saml_autocreate") && !is_user_member_of_blog($user_id, $site->id)) {
 			foreach($roles as $role) {
 				add_user_to_blog($site->id, $user_id, $role);
 			}


### PR DESCRIPTION
Issue: Undefined variable $site_id
Docs: https://developer.wordpress.org/reference/functions/get_sites/ 
Cause: get_sites returns an array of site objects, site_id not being defined causes issues when users login to sites that they have not logged into yet.